### PR TITLE
fix: put alias in match group

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 module.exports = options => {
   const aliases = Object.keys(options);
-  const re = new RegExp(`^${aliases.map(x => escapeRegExp(x)).join('|')}$`);
+  const re = new RegExp(`^(${aliases.map(x => escapeRegExp(x)).join('|')})$`);
 
   return {
     name: 'alias',


### PR DESCRIPTION
There's a very subtle bug with how the regex is created, it ends up as `^foo|bar$` where it would match input starting with `foo` OR ends with `bar`. I'm sure this wasn't intended.