### PR TITLE
Add .dts files to package

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,13 +3,15 @@
   "version": "0.2.0",
   "description": "esbuild plugin for path aliases",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "dev": "nodemon --exec 'npm run test' --watch index.js --watch tests",
     "test": "mocha",
     "lint": "eslint ."
   },
   "files": [
-    "index.js"
+    "index.js",
+    "index.d.ts"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
Thank you for providing this simple plugin.

I noticed that in the last release, you have added type definitions. However, those are not exported for the package yet, thus Typescript is unable to pick up on these types.

I added your type definition as exports to the package.json and tested it locally through `npm pack` within a typescript project. If you need to do any changes, feel free to do so.